### PR TITLE
Updated the examples so they work on Solara for both fixed sample and…

### DIFF
--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/RCode/AnalyzeUsingEastManualFormula.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/RCode/AnalyzeUsingEastManualFormula.R
@@ -40,9 +40,17 @@ AnalyzeUsingEastManualFormula<- function(SimData, DesignParam, LookInfo = NULL, 
     
     
     # Retrieve necessary information from the objects East sent
-    nLookIndex           <- LookInfo$CurrLookIndex
-    nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
-    nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
+
+    if(  !is.null( LookInfo )  )
+    {
+        nLookIndex           <- LookInfo$CurrLookIndex
+        nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
+    }
+    else
+    {
+        nLookIndex           <- 1
+        nQtyOfPatsInAnalysis <- nrow( SimData )
+    }
     
     # Create the vector of simulated data for this IA - East sends all of the simulated data
     vPatientOutcome      <- SimData$Response[ 1:nQtyOfPatsInAnalysis ]
@@ -68,7 +76,15 @@ AnalyzeUsingEastManualFormula<- function(SimData, DesignParam, LookInfo = NULL, 
     dZj                  <- ( dPiHatExperimental - dPiHatControl )/sqrt( dPiHatj*( 1- dPiHatj ) * ( 1/nQtyOfPatsOnE + 1/nQtyOfPatsOnS)  ) 
     
     # A decision of 2 means success, 0 means continue the trial
-    nDecision            <- ifelse( dZj > LookInfo$EffBdryUpper[ nLookIndex], 2, 0 )  
+    if(  !is.null( LookInfo )  )
+    {
+        nDecision            <- ifelse( dZj > LookInfo$EffBdryUpper[ nLookIndex], 2, 0 )  
+    }
+    else
+    {
+        nDecision            <- ifelse( dZj > DesignParam$CriticalPoint, 2, 0 )    
+    }
+    
     
     if( nDecision == 0 )
     {

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/RCode/AnalyzeUsingEastManualFormula.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/RCode/AnalyzeUsingEastManualFormula.R
@@ -44,11 +44,13 @@ AnalyzeUsingEastManualFormula<- function(SimData, DesignParam, LookInfo = NULL, 
     if(  !is.null( LookInfo )  )
     {
         nLookIndex           <- LookInfo$CurrLookIndex
+        nQtyOfLooks          <- LookInfo$NumLooks
         nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
     }
     else
     {
         nLookIndex           <- 1
+        nQtyOfLooks          <- 1
         nQtyOfPatsInAnalysis <- nrow( SimData )
     }
     
@@ -88,8 +90,12 @@ AnalyzeUsingEastManualFormula<- function(SimData, DesignParam, LookInfo = NULL, 
     
     if( nDecision == 0 )
     {
-        # For this example, there is NO futility check but this is left for consistency with other examples 
-        
+        # Did not hit efficacy, so check futility 
+        # We are at the FA, efficacy decision was not made yet so the decision is futility
+        if( nLookIndex == nQtyOfLooks ) 
+        {
+            nDecision <- 3 # Code for futility 
+        }
     }
     
     Error <-  0

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/RCode/AnalyzeUsingPropTest.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/RCode/AnalyzeUsingPropTest.R
@@ -68,10 +68,12 @@ AnalyzeUsingPropTest<- function(SimData, DesignParam, LookInfo = NULL, UserParam
     }
     if( nDecision == 0 )
     {
-        # if needed, check futility
-        
-        
-        
+        # Did not hit efficacy, so check futility 
+        # We are at the FA, efficacy decision was not made yet so the decision is futility
+        if( nLookIndex == nQtyOfLooks ) 
+        {
+            nDecision <- 3 # Code for futility 
+        }
     }
     
     Error 	= 0

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/RCode/AnalyzeUsingPropTest.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/RCode/AnalyzeUsingPropTest.R
@@ -57,8 +57,15 @@ AnalyzeUsingPropTest<- function(SimData, DesignParam, LookInfo = NULL, UserParam
     lAnalysisResult      <- prop.test(mData, alternative = "greater", correct = FALSE)
     dPValue              <- lAnalysisResult$p.value
     dZValue              <- qnorm( 1 - dPValue )
-    nDecision            <- ifelse( dZValue > LookInfo$EffBdryUpper[ nLookIndex], 2, 0 )  # A decision of 2 means success, 0 means continue the trial
     
+    if(  !is.null( LookInfo )  )
+    {
+        nDecision            <- ifelse( dZValue > LookInfo$EffBdryUpper[ nLookIndex], 2, 0 )  # A decision of 2 means success, 0 means continue the trial  
+    }
+    else
+    {
+        nDecision            <- ifelse( dZValue > DesignParam$CriticalPoint, 2, 0 )    
+    }
     if( nDecision == 0 )
     {
         # if needed, check futility

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingEastManualFormulaNormal.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingEastManualFormulaNormal.R
@@ -47,11 +47,13 @@ AnalyzeUsingEastManualFormulaNormal <- function(SimData, DesignParam, LookInfo =
     if(  !is.null( LookInfo )  )
     {
         nLookIndex           <- LookInfo$CurrLookIndex
+        nQtyOfLooks          <- LookInfo$NumLooks
         nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
     }
     else
     {
         nLookIndex           <- 1
+        nQtyOfLooks          <- 1
         nQtyOfPatsInAnalysis <- nrow( SimData )
     }
     
@@ -89,8 +91,12 @@ AnalyzeUsingEastManualFormulaNormal <- function(SimData, DesignParam, LookInfo =
     }
     if( nDecision == 0 )
     {
-        # For this example, there is NO futility check but this is left for consistency with other examples 
-        
+        # Did not hit efficacy, so check futility 
+        # We are at the FA, efficacy decision was not made yet so the decision is futility
+        if( nLookIndex == nQtyOfLooks ) 
+        {
+            nDecision <- 3 # Code for futility 
+        }
     }
     
     Error <-  0

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingEastManualFormulaNormal.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingEastManualFormulaNormal.R
@@ -33,20 +33,27 @@
 #######################################################################################################################################################################################################################
 
 
-AnalyzeUsingEastManualFormulaNormal <- function(SimData, DesignParam, LookInfo, UserParam = NULL )
+AnalyzeUsingEastManualFormulaNormal <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL )
 {
     # Input objects can be saved through the following lines:
 
-    setwd( "D:\\Project\\backup_cynergy\\")
-    saveRDS( SimData, "SimData.Rds")
-    saveRDS( DesignParam, "DesignParam.Rds" )
-    saveRDS( LookInfo, "LookInfo.Rds" )
+    # setwd( "D:\\Project\\backup_cynergy\\")
+    # saveRDS( SimData, "SimData.Rds")
+    # saveRDS( DesignParam, "DesignParam.Rds" )
+    # saveRDS( LookInfo, "LookInfo.Rds" )
 
     
     # Retrieve necessary information from the objects East sent
-    nLookIndex           <- LookInfo$CurrLookIndex
-    nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
-    nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
+    if(  !is.null( LookInfo )  )
+    {
+        nLookIndex           <- LookInfo$CurrLookIndex
+        nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
+    }
+    else
+    {
+        nLookIndex           <- 1
+        nQtyOfPatsInAnalysis <- nrow( SimData )
+    }
     
     # Create the vector of simulated data for this IA - East sends all of the simulated data
     vPatientOutcome      <- SimData$Response[ 1:nQtyOfPatsInAnalysis ]
@@ -72,8 +79,14 @@ AnalyzeUsingEastManualFormulaNormal <- function(SimData, DesignParam, LookInfo, 
     dZj                  <- ( dMeanOfResponsesOnE - dMeanOfResponsesOnS )/( dStdDevPooled * sqrt( 1/nQtyOfPatsOnE + 1/nQtyOfPatsOnS ))
     
     # A decision of 2 means success, 0 means continue the trial
-    nDecision            <- ifelse( dZj > LookInfo$EffBdryUpper[ nLookIndex ], 2, 0 )  
-    
+    if(  !is.null( LookInfo )  )
+    {
+        nDecision            <- ifelse( dZj > LookInfo$EffBdryUpper[ nLookIndex], 2, 0 )  
+    }
+    else
+    {
+        nDecision            <- ifelse( dZj > DesignParam$CriticalPoint, 2, 0 )    
+    }
     if( nDecision == 0 )
     {
         # For this example, there is NO futility check but this is left for consistency with other examples 

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingMeanLimitsOfCI.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingMeanLimitsOfCI.R
@@ -57,7 +57,6 @@ AnalyzeUsingMeanLimitsOfCI <- function(SimData, DesignParam, LookInfo = NULL, Us
         # Group sequential design
         nLookIndex           <- LookInfo$CurrLookIndex
         nQtyOfLooks          <- LookInfo$NumLooks
-        nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
         nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
     }
     else
@@ -65,7 +64,6 @@ AnalyzeUsingMeanLimitsOfCI <- function(SimData, DesignParam, LookInfo = NULL, Us
         # Fixed Design
         nLookIndex           <- 1
         nQtyOfLooks          <- 1
-        nQtyOfEvents         <- DesignParam$MaxCompleters
         nQtyOfPatsInAnalysis <- nrow( SimData )
     }
     

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingTTestNormal.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingTTestNormal.R
@@ -30,7 +30,7 @@
 #' 
 #######################################################################################################################################################################################################################
 
-AnalyzeUsingTTestNormal <- function( SimData, DesignParam, LookInfo, UserParam = NULL )
+AnalyzeUsingTTestNormal <- function( SimData, DesignParam, LookInfo = NULL, UserParam = NULL )
 {   
        # Input objects can be saved through the following lines:
     
@@ -41,10 +41,16 @@ AnalyzeUsingTTestNormal <- function( SimData, DesignParam, LookInfo, UserParam =
 
     
     # Retrieve necessary information from the objects East sent
-    nLookIndex           <- LookInfo$CurrLookIndex
-    nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
-    nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
-    
+    if(  !is.null( LookInfo )  )
+    {
+        nLookIndex           <- LookInfo$CurrLookIndex
+        nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
+    }
+    else
+    {
+        nLookIndex           <- 1
+        nQtyOfPatsInAnalysis <- nrow( SimData )
+    }
     # Create the vector of simulated data for this IA - East sends all of the simulated data
     vPatientOutcome      <- SimData$Response[ 1:nQtyOfPatsInAnalysis ]
     vPatientTreatment    <- SimData$TreatmentID[ 1:nQtyOfPatsInAnalysis ]
@@ -70,8 +76,15 @@ AnalyzeUsingTTestNormal <- function( SimData, DesignParam, LookInfo, UserParam =
                                      var.equal = TRUE)
     
     dTValue              <- lAnalysisResult$statistic    # extract t-test statistic value
-    nDecision            <- ifelse( dTValue > LookInfo$EffBdryUpper[ nLookIndex ], 2, 0 )  # A decision of 2 means success, 0 means continue the trial
     
+    if(  !is.null( LookInfo )  )
+    {
+        nDecision            <- ifelse( dTValue > LookInfo$EffBdryUpper[ nLookIndex ], 2, 0 )  # A decision of 2 means success, 0 means continue the trial  
+    }
+    else
+    {
+        nDecision            <- ifelse( dTValue > DesignParam$CriticalPoint, 2, 0 )    
+    }
     
     if( nDecision == 0 )
     {

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingTTestNormal.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/RCode/AnalyzeUsingTTestNormal.R
@@ -44,11 +44,13 @@ AnalyzeUsingTTestNormal <- function( SimData, DesignParam, LookInfo = NULL, User
     if(  !is.null( LookInfo )  )
     {
         nLookIndex           <- LookInfo$CurrLookIndex
+        nQtyOfLooks          <- LookInfo$NumLooks
         nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
     }
     else
     {
         nLookIndex           <- 1
+        nQtyOfLooks          <- 1
         nQtyOfPatsInAnalysis <- nrow( SimData )
     }
     # Create the vector of simulated data for this IA - East sends all of the simulated data
@@ -88,8 +90,12 @@ AnalyzeUsingTTestNormal <- function( SimData, DesignParam, LookInfo = NULL, User
     
     if( nDecision == 0 )
     {
-        # For this example, there is NO futility check but this is left for consistency with other examples 
-        
+        # Did not hit efficacy, so check futility 
+        # We are at the FA, efficacy decision was not made yet so the decision is futility
+        if( nLookIndex == nQtyOfLooks ) 
+        {
+            nDecision <- 3 # Code for futility 
+        }
     }
     
     Error <-  0

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingEastLogrankFormula.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingEastLogrankFormula.R
@@ -73,7 +73,7 @@ AnalyzeUsingEastLogrankFormula <- function(SimData, DesignParam, LookInfo = NULL
         # Look info was provided so use it
         nQtyOfLooks          <- LookInfo$NumLooks
         nLookIndex           <- LookInfo$CurrLookIndex
-        nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
+        nQtyOfEvents         <- LookInfo$CumCompleters[ nLookIndex ]
         dEffBdry             <- LookInfo$EffBdryLower[ nLookIndex ]
     }
     else

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingEastLogrankFormula.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingEastLogrankFormula.R
@@ -24,7 +24,7 @@
 #'                 for example LookInfo$NumLooks and not order. Other important variables in group sequential designs are: 
 #'                   LookInfo$NumLooks An integer value with the number of looks in the study
 #'                   LookInfo$CurrLookIndex An integer value with the current index look, starting from 1
-#'                   LookInfo$CumEvents A vector of length LookInfo$NumLooks that contains the number of events at the look.
+#'                   LookInfo$InfoFrac A numeric vector containing information fraction
 #' @param UserParam User can pass custom scalar variables defined by users as a member of this list. 
 #'                  User should access the variables using names, for example UserParam$Var1 and not order. 
 #'                  These variables can be of the following types: Integer, Numeric, or Character
@@ -73,7 +73,8 @@ AnalyzeUsingEastLogrankFormula <- function(SimData, DesignParam, LookInfo = NULL
         # Look info was provided so use it
         nQtyOfLooks          <- LookInfo$NumLooks
         nLookIndex           <- LookInfo$CurrLookIndex
-        nQtyOfEvents         <- LookInfo$CumCompleters[ nLookIndex ]
+        CumEvents            <- LookInfo$InfoFrac*DesignParam$MaxEvents
+        nQtyOfEvents         <- CumEvents[ nLookIndex ]
         dEffBdry             <- LookInfo$EffBdryLower[ nLookIndex ]
     }
     else

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingEastLogrankFormula.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingEastLogrankFormula.R
@@ -64,6 +64,9 @@
 
 AnalyzeUsingEastLogrankFormula <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL )
 {
+          # saveRDS( SimData,     "SimData.Rds")
+          # saveRDS( DesignParam, "DesignParam.Rds" )
+          # saveRDS( LookInfo,    "LookInfo.Rds" )
     # Retrieve necessary information from the objects East sent
     if( !is.null( LookInfo ) )
     {

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingEastLogrankFormula.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingEastLogrankFormula.R
@@ -157,8 +157,12 @@ AnalyzeUsingEastLogrankFormula <- function(SimData, DesignParam, LookInfo = NULL
     
     if( nDecision == 0 )
     {
-        # For this example, there is NO futility check but this is left for consistency with other examples 
-        
+        # Did not hit efficacy, so check futility 
+        # We are at the FA, efficacy decision was not made yet so the decision is futility
+        if( nLookIndex == nQtyOfLooks ) 
+        {
+            nDecision <- 3 # Code for futility 
+        }
     }
 
     Error    <- 0

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingHazardRatioLimitsOfCI.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingHazardRatioLimitsOfCI.R
@@ -60,7 +60,7 @@ AnalyzeUsingHazardRatioLimitsOfCI <- function(SimData, DesignParam, LookInfo = N
         # Look info was provided so use it
         nQtyOfLooks          <- LookInfo$NumLooks
         nLookIndex           <- LookInfo$CurrLookIndex
-        nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
+        nQtyOfEvents         <- LookInfo$CumCompleters[ nLookIndex ]
         dEffBdry             <- LookInfo$EffBdryLower[ nLookIndex ]
     }else
     {   # Look info is not provided for fixed sample designs so fetch the information appropriately

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingHazardRatioLimitsOfCI.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingHazardRatioLimitsOfCI.R
@@ -60,7 +60,8 @@ AnalyzeUsingHazardRatioLimitsOfCI <- function(SimData, DesignParam, LookInfo = N
         # Look info was provided so use it
         nQtyOfLooks          <- LookInfo$NumLooks
         nLookIndex           <- LookInfo$CurrLookIndex
-        nQtyOfEvents         <- LookInfo$CumCompleters[ nLookIndex ]
+        CumEvents            <- LookInfo$InfoFrac*DesignParam$MaxEvents
+        nQtyOfEvents         <- CumEvents[ nLookIndex ]
         dEffBdry             <- LookInfo$EffBdryLower[ nLookIndex ]
     }else
     {   # Look info is not provided for fixed sample designs so fetch the information appropriately

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingSurvivalPackage.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingSurvivalPackage.R
@@ -87,14 +87,11 @@ AnalyzeUsingSurvivalPackage <- function(SimData, DesignParam, LookInfo = NULL, U
     
     if( nDecision == 0 )
     {
-        # For this example, there is NO futility check but this is left for consistency with other examples 
         # At the final analysis we want to make a futility if efficacy was not achieved.
-        
         # We are at the FA, efficacy decision was not made yet so the decision is futility
         if( nLookIndex == nQtyOfLooks ) 
         {
-            # The final analysis was reached and a Go decision could not be made, thus a No Go decision is made
-            nDecision <- 3                                    # East code for futility 
+            nDecision <- 3 # Code for futility 
         }
     }
     

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingSurvivalPackage.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingSurvivalPackage.R
@@ -46,7 +46,7 @@ AnalyzeUsingSurvivalPackage <- function(SimData, DesignParam, LookInfo = NULL, U
         # Look info was provided so use it
         nQtyOfLooks          <- LookInfo$NumLooks
         nLookIndex           <- LookInfo$CurrLookIndex
-        nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
+        nQtyOfEvents         <- LookInfo$CumCompleters[ nLookIndex ]
         dEffBdry             <- LookInfo$EffBdryLower[ nLookIndex ]
     }
     else

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingSurvivalPackage.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingSurvivalPackage.R
@@ -46,7 +46,8 @@ AnalyzeUsingSurvivalPackage <- function(SimData, DesignParam, LookInfo = NULL, U
         # Look info was provided so use it
         nQtyOfLooks          <- LookInfo$NumLooks
         nLookIndex           <- LookInfo$CurrLookIndex
-        nQtyOfEvents         <- LookInfo$CumCompleters[ nLookIndex ]
+        CumEvents            <- LookInfo$InfoFrac*DesignParam$MaxEvents
+        nQtyOfEvents         <- CumEvents[ nLookIndex ]
         dEffBdry             <- LookInfo$EffBdryLower[ nLookIndex ]
     }
     else

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingSurvivalPackage.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/RCode/AnalyzeUsingSurvivalPackage.R
@@ -88,7 +88,7 @@ AnalyzeUsingSurvivalPackage <- function(SimData, DesignParam, LookInfo = NULL, U
     if( nDecision == 0 )
     {
         # For this example, there is NO futility check but this is left for consistency with other examples 
-        # At the final analysis we want to make a futility if effiecacy was not achieved.
+        # At the final analysis we want to make a futility if efficacy was not achieved.
         
         # We are at the FA, efficacy decision was not made yet so the decision is futility
         if( nLookIndex == nQtyOfLooks ) 


### PR DESCRIPTION
… group sequential designs

Hello Kyle, we've tested the r functions in the Examples folder on Solara. We've not tested Assurance and Treatment selection since they are not available on Solara yet. Additionally, we discovered a bug where for TTE, engine is not correctly passing Cumulative events (CumEvents) information to the r function. The workaround right now is to use another field called CumCompleters which contains the data that CumEvents should have contained. We'll raise a bug for this. I've modified the r function incorporating this workaround but i've not changed the parameter description. 
Testing of the examples is documented here - https://cytel1.atlassian.net/wiki/spaces/platform/pages/3422060551/CyneRgy+Testing+of+R+Examples+with+East+Horizon