### PR TITLE
Remove confusing RDS guidance

### DIFF
--- a/R/CreateCyneRgyFunction.R
+++ b/R/CreateCyneRgyFunction.R
@@ -43,7 +43,7 @@ CreateCyneRgyFunction <- function( strFunctionType = "", strNewFunctionName = NA
     
     
     
-    #TODO: Make sure the strFunctionType is a valid type, eg PatientSimulator, Analysis ect
+    #: Make sure the strFunctionType is a valid type, eg PatientSimulator, Analysis ect
     # Make sure the file does not already exist
     # create it and open it
     strPackage <- "CyneRgy"

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingBayesAnalysisWithFutility-FillInTheBlank.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingBayesAnalysisWithFutility-FillInTheBlank.R
@@ -1,7 +1,4 @@
 ######################################################################################################################## .
-#' TODO(Kyle): I am not sure how to define the alpha and beta user parameters. Could you define and add to documentation?
-#' TODO(Kyle): Should the functions at the bottom be left at the bottom or do they need to be added to top documentation?
-#' 
 #' @param AnalyzeUsingBayesAnalysisWithFutility
 #' @title Analyze for efficacy using a beta prior to compute the posterior probability that experimental is better than standard of care. 
 #' @param SimData Data frame which consists of data generated in current simulation.
@@ -69,9 +66,7 @@ AnalyzeUsingBayesAnalysisWithFutility <- function(SimData, DesignParam, LookInfo
     vOutcomesS           <- vPatientOutcome[ vPatientTreatment == 0 ]
     vOutcomesE           <- ___________[ vPatientTreatment == 1 ]
     
-    #TODO(Kyle): Should this below note move into the top formatting section?
-    
-    
+
     # Important Note: 
     # When using simulation to obtain the frequentist Operating Characteristic (OC) of a Bayesian design, you should set dLowerCutoffForFutility = 0
     # when simulating under the null case in order to obtain the false-positive rate of the non-binding futility rule.  

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingBayesAnalysisWithFutility-FillInTheBlank.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingBayesAnalysisWithFutility-FillInTheBlank.R
@@ -35,15 +35,6 @@
 #       If user variables are not specifed we assume:
 #       pi_S ~ beta( 10, 40 ); to reflect that knowledge that on standard of care 10/50 previous patients responded
 #       pi_E ~ beta( 0.2, 0.8 ); non-informative prior for Experimental to have the same prior mean as S but only 1 prior patient observed
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
 
 ######################################################################################################################## .
 
@@ -106,12 +97,6 @@ AnalyzeUsingBayesAnalysisWithFutility <- function(SimData, DesignParam, LookInfo
         
     }
     
-    if( !file.exists( paste0( "SimData", nLookIndex, ".Rds") ))
-    {
-        saveRDS( SimData, paste0( "SimData", nLookIndex, ".Rds") )
-        saveRDS( DesignParam, paste0( "DesignParam", nLookIndex, ".Rds") )
-        saveRDS( LookInfo, paste0( "LookInfo", nLookIndex, ".Rds") )
-    }
     Error 	<- 0
     #retval 	= 0
     

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingEastManualFormula-FillInTheBlank.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingEastManualFormula-FillInTheBlank.R
@@ -18,9 +18,6 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Non fatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
-
-
-
 ######################################################################################################################## .
 
 AnalyzeUsingEastManualFormula<- function(SimData, DesignParam, LookInfo, UserParam = NULL)

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingEastManualFormula-FillInTheBlank.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingEastManualFormula-FillInTheBlank.R
@@ -19,15 +19,7 @@
 #                                       ErrorCode > 0 --> Non fatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 
 ######################################################################################################################## .
 
@@ -36,13 +28,6 @@ AnalyzeUsingEastManualFormula<- function(SimData, DesignParam, LookInfo, UserPar
     # In this example, the majority of the code is provided.  The fill in the blank areas are noted by _____________________.
     # This is done to allow you to practice creating these examples. You will need to remove the ____________ and enter the correct code.
     # The fully worked examples are provided in the corresponding example R files.
-    # Input objects can be saved through the following lines:
-    
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-    
     
     # Retrieve necessary information from the objects East sent
     nLookIndex           <- LookInfo$CurrLookIndex

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingPropLimitsofCI-Fill-in-the-Blank.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingPropLimitsofCI-Fill-in-the-Blank.R
@@ -23,15 +23,7 @@
 #                                       ErrorCode > 0 --> Non fatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 
 ######################################################################################################################## .
 AnalyzeUsingPropLimitsOfCI<- function(SimData, DesignParam, LookInfo, UserParam = NULL)
@@ -51,17 +43,6 @@ AnalyzeUsingPropLimitsOfCI<- function(SimData, DesignParam, LookInfo, UserParam 
     nQtyOfLooks          <- LookInfo$NumLooks
     nLookIndex           <- LookInfo$CurrLookIndex
     nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
-    
-    # Input objects can be saved through the following lines:
-    
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-    
-    
-    
-    
     
     nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
     

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingPropLimitsofCI-Fill-in-the-Blank.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingPropLimitsofCI-Fill-in-the-Blank.R
@@ -22,14 +22,10 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Non fatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
-
-
-
 ######################################################################################################################## .
+
 AnalyzeUsingPropLimitsOfCI<- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 {
-    
-    
     # In this example, the majority of the code is provided.  The fill in the blank areas are noted by _____________________.
     # This is done to allow you to practice creating these examples. You will need to remove the ____________ and enter the correct code.
     # The fully worked examples are provided in the corresponding example R files. 

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingPropTest-FillInTheBlank.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingPropTest-FillInTheBlank.R
@@ -19,15 +19,6 @@
 #                                       ErrorCode > 0 --> Non fatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
 ######################################################################################################################## .
 
 #TODO(Kyle)- I am not sure where to substitute in the user parameters since most seems to be sent from East and then analyzed using prop.test
@@ -37,22 +28,10 @@ AnalyzeUsingPropTest<- function(SimData, DesignParam, LookInfo, UserParam = NULL
     # This is done to allow you to practice creating these examples. You will need to remove the ____________ and enter the correct code.
     # The fully worked examples are provided in the corresponding example R files. 
     
-    
     # Retrieve necessary information from the objects East sent
     nLookIndex           <- LookInfo$CurrLookIndex
     nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
-    
-    # Input objects can be saved through the following lines:
-    
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-    nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
-    
-    
-    
-    
+     
     # Create the vector of simulated data for this IA - East sends all of the simulated data
     vPatientOutcome      <- SimData$Response[ 1:nQtyOfPatsInAnalysis ]
     vPatientTreatment    <- SimData$TreatmentID[ 1:nQtyOfPatsInAnalysis ]

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingPropTest-FillInTheBlank.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/FillInTheBlankR/AnalyzeUsingPropTest-FillInTheBlank.R
@@ -18,10 +18,8 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Non fatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
-
 ######################################################################################################################## .
 
-#TODO(Kyle)- I am not sure where to substitute in the user parameters since most seems to be sent from East and then analyzed using prop.test
 AnalyzeUsingPropTest<- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 {
     # In this example, the majority of the code is provided.  The fill in the blank areas are noted by _____________________.
@@ -31,6 +29,7 @@ AnalyzeUsingPropTest<- function(SimData, DesignParam, LookInfo, UserParam = NULL
     # Retrieve necessary information from the objects East sent
     nLookIndex           <- LookInfo$CurrLookIndex
     nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
+    nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
      
     # Create the vector of simulated data for this IA - East sends all of the simulated data
     vPatientOutcome      <- SimData$Response[ 1:nQtyOfPatsInAnalysis ]

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingBetaBinomial.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingBetaBinomial.R
@@ -70,15 +70,7 @@
 #'                  \item{Delta}{Estimated different between experimental and standard of care}
 #'                  }
 #'
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 ######################################################################################################################## .
 
 AnalyzeUsingBetaBinomial <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingBetaBinomial.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingBetaBinomial.R
@@ -70,7 +70,6 @@
 #'                  \item{Delta}{Estimated different between experimental and standard of care}
 #'                  }
 #'
-
 ######################################################################################################################## .
 
 AnalyzeUsingBetaBinomial <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingEastManualFormula.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingEastManualFormula.R
@@ -33,8 +33,6 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
-
-
 ######################################################################################################################## .
 
 AnalyzeUsingEastManualFormula<- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingEastManualFormula.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingEastManualFormula.R
@@ -34,15 +34,7 @@
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 ######################################################################################################################## .
 
 AnalyzeUsingEastManualFormula<- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingPropLimitsOfCI.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingPropLimitsOfCI.R
@@ -53,15 +53,7 @@
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 #'@note In this example, the boundary information that is computed and sent from East is ignored in order to implement this decision approach.
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 
 ######################################################################################################################## .
 AnalyzeUsingPropLimitsOfCI<- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingPropLimitsOfCI.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingPropLimitsOfCI.R
@@ -1,5 +1,4 @@
 ######################################################################################################################## .
-# TODO(Kyle)-Could you check that this documentation is correct (specifically the description)
 #' @param AnalyzeUsingPropLimitsOfCI
 #' @title Analyze using a simplified limits of confidence interval design
 #' @param SimData Data frame which consists of data generated in current simulation.
@@ -53,9 +52,8 @@
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 #'@note In this example, the boundary information that is computed and sent from East is ignored in order to implement this decision approach.
-
-
 ######################################################################################################################## .
+
 AnalyzeUsingPropLimitsOfCI<- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)
 {
     library(CyneRgy)

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingPropTest.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingPropTest.R
@@ -34,15 +34,7 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 ######################################################################################################################## .
 AnalyzeUsingPropTest<- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)
 {

--- a/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingPropTest.R
+++ b/inst/Examples/2ArmBinaryOutcomeAnalysis/R/AnalyzeUsingPropTest.R
@@ -34,8 +34,8 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
-
 ######################################################################################################################## .
+
 AnalyzeUsingPropTest<- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)
 {
     library(CyneRgy)

--- a/inst/Examples/2ArmBinaryOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZero.Binary.R
+++ b/inst/Examples/2ArmBinaryOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZero.Binary.R
@@ -23,17 +23,6 @@
 #'  outcome from a binomial distribution using the response probabilities provided in PropRest.  
 SimulatePatientOutcomePercentAtZero.Binary <- function( NumSub, NumArm, ArrivalTime, TreatmentID, PropResp, UserParam = NULL )
 {
-    # Note: It can be helpful to save to the parameters that East sent.
-    # The next two lines show how you could save the UserParam variable to an Rds file
-    # setwd(["ENTER THE DESIRED LOCATION TO SAVE THE FILE"])
-    # saveRDS( NumSub, "NumSub.Rds" )    
-    # saveRDS( NumArm, "NumArm.Rds" )
-    # saveRDS( TreatmentID, "TreatmentID.Rds" )
-    # saveRDS( PropResp, "PropResp.Rds" )
-    # saveRDS( UserParam, "UserParam.Rds")    
-    # If the user did not specify the user parameters, but still called this function then the probability
-    # of treatment resistant is 0 for both treatments
-    
     if( is.null( UserParam ) )
     {
         UserParam <- list( dProbOfTreatmentResistantCtrl = 0, dProbOfTreatmentResistantExp = 0 )

--- a/inst/Examples/2ArmBinaryOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZeroBetaDist.Binary.R
+++ b/inst/Examples/2ArmBinaryOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZeroBetaDist.Binary.R
@@ -20,11 +20,6 @@
 #' The intent of this option is to incorporate the variability in the unknown, probability of no response, quantity.  
 SimulatePatientOutcomePercentAtZeroBetaDist.Binary <- function( NumSub, NumArm, ArrivalTime, TreatmentID, PropResp, UserParam = NULL )
 {
-    # Note: It can be helpful to save to the parameters that East sent.
-    # The next two lines show how you could save the UserParam variable to an Rds file
-    # setwd( "[ENTER THE DESIRED LOCATION TO SAVE THE FILE]" )
-    # saveRDS(UserParam, "UserParam.Rds")
-    
     # If the user did not specify the user parameters, but still called this function then the probability
     # of a 0 outcome is 0 for both treatments
     if( is.null( UserParam ) )

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingEastManualFormulaNormal.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingEastManualFormulaNormal.R
@@ -20,15 +20,7 @@
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 #' @export
 #' 
 #######################################################################################################################################################################################################################

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingEastManualFormulaNormal.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingEastManualFormulaNormal.R
@@ -19,8 +19,6 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
-
-
 #' @export
 #' 
 #######################################################################################################################################################################################################################

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingMeanLimitsOfCI.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingMeanLimitsOfCI.R
@@ -38,9 +38,8 @@
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 #'@note This function is only applicable to the case where MAV <= TV.  
 #'       In this example, the boundary information that is computed and sent from East is ignored in order to implement this decision approach.
-
-
 ################################################################################################################################################################################################
+
 AnalyzeUsingMeanLimitsOfCI <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)
 {
     library(CyneRgy)

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingMeanLimitsOfCI.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingMeanLimitsOfCI.R
@@ -38,15 +38,7 @@
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 #'@note This function is only applicable to the case where MAV <= TV.  
 #'       In this example, the boundary information that is computed and sent from East is ignored in order to implement this decision approach.
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 
 ################################################################################################################################################################################################
 AnalyzeUsingMeanLimitsOfCI <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingTTestNormal.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingTTestNormal.R
@@ -16,8 +16,6 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
-
-
 #' @export
 #' 
 #' 

--- a/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingTTestNormal.R
+++ b/inst/Examples/2ArmNormalOutcomeAnalysis/R/AnalyzeUsingTTestNormal.R
@@ -17,15 +17,7 @@
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 #' @export
 #' 
 #' 

--- a/inst/Examples/2ArmNormalOutcomePatientSimulation/FillInTheBlankR/SimulatePatientOutcomePercentAtZero.R
+++ b/inst/Examples/2ArmNormalOutcomePatientSimulation/FillInTheBlankR/SimulatePatientOutcomePercentAtZero.R
@@ -15,11 +15,6 @@
 #' simulated from a normal distribution with the mean and standard deviation as sent from East. 
 SimulatePatientOutcomePercentAtZero <- function(NumSub, ArrivalTime, TreatmentID, Mean, StdDev, UserParam = NULL)
 {
-    # Note: It can be helpful to save to the parameters that East sent.
-    # The next two lines show how you could save the UserParam variable to an Rds file
-    # setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    # saveRDS(UserParam, "UserParam.Rds")
-    
     # If the user did not specify the user parameters, but still called this function then the probability
     # of a 0 outcome is 0 for both treatments
     if( is.null( UserParam ) )

--- a/inst/Examples/2ArmNormalOutcomePatientSimulation/FillInTheBlankR/SimulatePatientOutcomePercentAtZeroBetaDist.R
+++ b/inst/Examples/2ArmNormalOutcomePatientSimulation/FillInTheBlankR/SimulatePatientOutcomePercentAtZeroBetaDist.R
@@ -20,11 +20,6 @@
 #' The intent of this option is to incorporate the variability in the unknown, probability of no response, quantity.  
 SimulatePatientOutcomePercentAtZeroBetaDist <- function(NumSub, ArrivalTime, TreatmentID, Mean, StdDev, ________________________)
 {
-    # Note: It can be helpful to save to the parameters that East sent.
-    # The next two lines show how you could save the UserParam variable to an Rds file
-    # setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    # saveRDS(UserParam, "UserParam.Rds")
-    
     # If the user did not specify the user parameters, but still called this function then the probability
     # of a 0 outcome is 0 for both treatments
     if( is.null( ___________ ) )

--- a/inst/Examples/2ArmNormalOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZero.R
+++ b/inst/Examples/2ArmNormalOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZero.R
@@ -15,15 +15,6 @@
 #' simulated from a normal distribution with the mean and standard deviation as sent from East. 
 SimulatePatientOutcomePercentAtZero <- function(NumSub, ArrivalTime, TreatmentID, Mean, StdDev, UserParam = NULL)
 {
-    # Note: It can be helpful to save to the parameters that East sent.
-    # The next two lines show how you could save the UserParam variable to an Rds file
-    # setwd( "C:/EastRWebinar/Webinar1/2ArmNormalOutcomePatientSimulation/ExampleEastOutput/" )
-    # saveRDS( NumSub, "NumSub.Rds" )
-    # saveRDS( TreatmentID, "TreatmentID.Rds" )
-    # saveRDS( Mean, "Mean.Rds" )
-    # saveRDS( StdDev, "StdDev.Rds" )
-    # saveRDS( UserParam, "UserParam.Rds" )
-    
     # If the user did not specify the user parameters, but still called this function then the probability
     # of a 0 outcome is 0 for both treatments
     if( is.null( UserParam ) )

--- a/inst/Examples/2ArmNormalOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZeroBetaDist.R
+++ b/inst/Examples/2ArmNormalOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZeroBetaDist.R
@@ -18,8 +18,7 @@
 #' The probability of 0 outcome on the experimental treatment is sampled from a Beta( UserParam$dExpBetaParam1, UserParam$dExpBetaParam2 ) distribution.
 #' The intent of this option is to incorporate the variability in the unknown, probability of no response, quantity.  
 SimulatePatientOutcomePercentAtZeroBetaDist <- function(NumSub, ArrivalTime, TreatmentID, Mean, StdDev, UserParam = NULL)
-{
-    
+{ 
     # If the user did not specify the user parameters, but still called this function then the probability
     # of a 0 outcome is 0 for both treatments
     if( is.null( UserParam ) )

--- a/inst/Examples/2ArmNormalOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZeroBetaDist.R
+++ b/inst/Examples/2ArmNormalOutcomePatientSimulation/R/SimulatePatientOutcomePercentAtZeroBetaDist.R
@@ -19,10 +19,6 @@
 #' The intent of this option is to incorporate the variability in the unknown, probability of no response, quantity.  
 SimulatePatientOutcomePercentAtZeroBetaDist <- function(NumSub, ArrivalTime, TreatmentID, Mean, StdDev, UserParam = NULL)
 {
-    # Note: It can be helpful to save to the parameters that East sent.
-    # The next two lines show how you could save the UserParam variable to an Rds file
-    # setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    # saveRDS(UserParam, "UserParam.Rds")
     
     # If the user did not specify the user parameters, but still called this function then the probability
     # of a 0 outcome is 0 for both treatments

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingEastLogrankFormula.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingEastLogrankFormula.R
@@ -51,8 +51,6 @@
 #'                                            Used in Solara for creating the observed hazard ratio graph. 
 #'                                            Only applicable for time-to-event data.}
 #'                                            
-
-
 ######################################################################################################################## .
 
 AnalyzeUsingEastLogrankFormula <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL )

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingEastLogrankFormula.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingEastLogrankFormula.R
@@ -52,15 +52,7 @@
 #'                                            Only applicable for time-to-event data.}
 #'                                            
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 ######################################################################################################################## .
 
 AnalyzeUsingEastLogrankFormula <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL )

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingHazardRatioLimitsOfCI.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingHazardRatioLimitsOfCI.R
@@ -43,15 +43,7 @@
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted.
 
 #'@note In this example, the boundary information that is computed and sent from East is ignored in order to implement this decision approach.
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 
 ################################################################################################################################################################################################
 AnalyzeUsingHazardRatioLimitsOfCI <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingHazardRatioLimitsOfCI.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingHazardRatioLimitsOfCI.R
@@ -41,11 +41,9 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted.
-
-#'@note In this example, the boundary information that is computed and sent from East is ignored in order to implement this decision approach.
-
-
+#'@note In this example, the boundary information that is computed and sent from East Horizon is ignored in order to implement this decision approach.
 ################################################################################################################################################################################################
+
 AnalyzeUsingHazardRatioLimitsOfCI <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)
 {   
     library(CyneRgy)

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingSurvivalPackage.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingSurvivalPackage.R
@@ -18,8 +18,6 @@
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
-
-
 ######################################################################################################################## .
 
 AnalyzeUsingSurvivalPackage <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL )

--- a/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingSurvivalPackage.R
+++ b/inst/Examples/2ArmTimeToEventOutcomeAnalysis/R/AnalyzeUsingSurvivalPackage.R
@@ -19,15 +19,7 @@
 #                                       ErrorCode > 0 --> Nonfatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 ######################################################################################################################## .
 
 AnalyzeUsingSurvivalPackage <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL )

--- a/inst/Examples/BayesianAssuranceContinuous/R/AnalyzeUsingBayesianNormals.R
+++ b/inst/Examples/BayesianAssuranceContinuous/R/AnalyzeUsingBayesianNormals.R
@@ -17,23 +17,10 @@
 #' @export
 AnalyzeUsingBayesianNormals <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)
 {
-    
-    # setwd( "C:/AssuranceNormal/ExampleArgumentsFromEast/Example4")
-    # if( !file.exists("SimData.Rds"))
-    # {
-    #     saveRDS( SimData,     "SimData.Rds")
-    #    saveRDS( DesignParam, "DesignParam.Rds" )
-    #    saveRDS( UserParam,   "UserParam.Rds")
-    #    saveRDS( LookInfo,   "LookInfo.Rds")
-    # }
-    
-    
     bInterimAnalysis <- FALSE   # Assuming a fixed design, the next if statement will check this
 
     if( missing( LookInfo ) == FALSE && !is.null( LookInfo ) )
     {
-        
-        #saveRDS( LookInfo,    "LookInfo.Rds" )
         # Step 1 - If this is the IA then subset the data to include only those for the first look. East sends all simulated data
         
         if(  LookInfo$CurrLookIndex == 1 )

--- a/inst/Examples/BayesianAssuranceContinuous/R/AnalyzeUsingBayesianNormals.R
+++ b/inst/Examples/BayesianAssuranceContinuous/R/AnalyzeUsingBayesianNormals.R
@@ -15,6 +15,7 @@
 #'    \item{UserParam$dPUFutility}{A value in [0, 1] that specifies the threshold probability of futility stopping. If the predictive probability of a No Go decision at the end exceeds this value, the trial is stopped early for futility.}
 #'    }
 #' @export
+
 AnalyzeUsingBayesianNormals <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)
 {
     bInterimAnalysis <- FALSE   # Assuming a fixed design, the next if statement will check this

--- a/inst/Examples/BayesianAssuranceContinuous/R/SimulatePatientOutcomeNormalAssurance.R
+++ b/inst/Examples/BayesianAssuranceContinuous/R/SimulatePatientOutcomeNormalAssurance.R
@@ -22,17 +22,6 @@
 #' This template can be used as a starting point for developing custom functionality.  The function signature must remain the same.  
 SimulatePatientOutcomeNormalAssurance <- function(NumSub, ArrivalTime, TreatmentID, Mean, StdDev, UserParam = NULL)
 {
-    
-    # Note: Example of how you could save the parameters in East. Do NOT setwd in East Horizon
-    # setwd( "C:/AssuranceNormal/ExampleArgumentsFromEast/Example2")
-    # #if( !file.exists("SimData.Rds" ))
-    # #{
-        # saveRDS( NumSub,     "NumSub.Rds" )
-        # saveRDS( TreatmentID, "TreatmentID.Rds" )
-        # saveRDS( StdDev, "StdDev.Rds" )
-        # saveRDS( UserParam,   "UserParam.Rds" )
-    # #}
-    
     # Step 1 - Setup the vectors so we can sample which component of the mixture prior to use ####
     vStdDev     <- c( UserParam$dSDCtrl, UserParam$dSDExp )
     vMean       <- c( UserParam$dMeanCtrl )                     #Note: only need control mean as we will sample experimental mean

--- a/inst/Examples/BayesianAssuranceTimeToEvent/R/SimulatePatientSurvivalAssurance.R
+++ b/inst/Examples/BayesianAssuranceTimeToEvent/R/SimulatePatientSurvivalAssurance.R
@@ -40,17 +40,6 @@
 
 SimulatePatientSurvivalAssurance <- function(NumSub, NumArm, ArrivalTime, TreatmentID, SurvMethod, NumPrd, PrdTime, SurvParam, UserParam = NULL  ) 
 {
-    # The SurvParam depends on input in East, EAST sends the Medan (see the Simulation -> Response Generation tab for what is sent)
-    # setwd( "C:\\AssuranceNormal\\ExampleArgumentsFromEast\\Example3")
-    # #setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    # saveRDS( NumSub, "NumSub.Rds")
-    # saveRDS( NumArm, "NumArm.Rds" )
-    # saveRDS( TreatmentID, "TreatmentID.Rds" )
-    # saveRDS( SurvMethod, "SurvMethod.Rds" )
-    # saveRDS( NumPrd, "NumPrd.Rds" )
-    # saveRDS( SurvParam, "SurvParam.Rds" )
-    # saveRDS( UserParam, "UserParamSim.Rds" )
-    
     # Step 1 - Determine how many patients on each treatment need to be simulated ####
     vTrtAllocation <- table( TreatmentID )
     vSurvTime      <- rep( -1, NumSub )  # The vector of patient survival times that will be returned.  

--- a/inst/Examples/ConsecutiveStudiesContinuous/R/AnalyzeUsingBayesianNormals.R
+++ b/inst/Examples/ConsecutiveStudiesContinuous/R/AnalyzeUsingBayesianNormals.R
@@ -16,23 +16,10 @@
 #' @export
 AnalyzeUsingBayesianNormals <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)
 {
-    
-    # setwd( "C:/AssuranceNormal/ExampleArgumentsFromEast/Example4")
-    # if( !file.exists("SimData.Rds"))
-    # {
-    #     saveRDS( SimData,     "SimData.Rds")
-    #    saveRDS( DesignParam, "DesignParam.Rds" )
-    #    saveRDS( UserParam,   "UserParam.Rds")
-    #    saveRDS( LookInfo,   "LookInfo.Rds")
-    # }
-    
-    
     bInterimAnalysis <- FALSE   # Assuming a fixed design, the next if statement will check this
 
     if( missing( LookInfo ) == FALSE && !is.null( LookInfo ) )
     {
-        
-        #saveRDS( LookInfo,    "LookInfo.Rds" )
         # Step 1 - If this is the IA then subset the data to include only those for the first look. East sends all simulated data
         
         if(  LookInfo$CurrLookIndex == 1 )

--- a/inst/Examples/ConsecutiveStudiesContinuous/R/SimulatePatientOutcomeNormalAssurance.R
+++ b/inst/Examples/ConsecutiveStudiesContinuous/R/SimulatePatientOutcomeNormalAssurance.R
@@ -22,17 +22,6 @@
 #' This template can be used as a starting point for developing custom functionality.  The function signature must remain the same.  
 SimulatePatientOutcomeNormalAssurance <- function(NumSub, ArrivalTime, TreatmentID, Mean, StdDev, UserParam = NULL)
 {
-    
-    # Note: Example of how you could save the parameters in East. Do NOT setwd in Solara
-     #setwd( "C:/AssuranceNormal/ExampleArgumentsFromEast/Example2")
-    # #if( !file.exists("SimData.Rds"))
-    # #{
-        # saveRDS( NumSub,     "NumSub.Rds")
-        # saveRDS( TreatmentID, "TreatmentID.Rds" )
-        # saveRDS( StdDev, "StdDev.Rds" )
-        # saveRDS( UserParam,   "UserParam.Rds")
-    # #}
-    
     # Step 1 - Setup the vectors so we can sample which component of the mixture prior to use
     vStdDev     <- c( UserParam$dSDCtrl, UserParam$dSDExp )
     vMean       <- c( UserParam$dMeanCtrl )                     #Note: only need control mean as we will sample experimental mean

--- a/inst/Examples/ConsecutiveStudiesContinuousTimeToEvent/R/AnalyzeSurvivalDataUsingCoxPH.R
+++ b/inst/Examples/ConsecutiveStudiesContinuousTimeToEvent/R/AnalyzeSurvivalDataUsingCoxPH.R
@@ -5,8 +5,7 @@
 AnalyzeSurvivalDataUsingCoxPH <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL )
 {
     library( survival )
-    Error <- 0 
-  
+    Error <- 0   
     nLookIndex           <- 1 
     
     if( !is.null( LookInfo ) )

--- a/inst/Examples/ConsecutiveStudiesContinuousTimeToEvent/R/AnalyzeSurvivalDataUsingCoxPH.R
+++ b/inst/Examples/ConsecutiveStudiesContinuousTimeToEvent/R/AnalyzeSurvivalDataUsingCoxPH.R
@@ -6,14 +6,7 @@ AnalyzeSurvivalDataUsingCoxPH <- function(SimData, DesignParam, LookInfo = NULL,
 {
     library( survival )
     Error <- 0 
-    # Example of saving parameters (EAST ONLY)
-    # setwd( "C:\\AssuranceNormal\\ExampleArgumentsFromEast\\Example3")
-    # setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    # saveRDS( SimData, "SimData.Rds")
-    # saveRDS( DesignParam, "DesignParam.Rds" )
-    # saveRDS( LookInfo, "LookInfo.Rds" )
-    # saveRDS( UserParam, "UserParam.Rds" )
-    
+  
     nLookIndex           <- 1 
     
     if( !is.null( LookInfo ) )

--- a/inst/Examples/ConsecutiveStudiesContinuousTimeToEvent/R/AnalyzeUsingBayesianNormals.R
+++ b/inst/Examples/ConsecutiveStudiesContinuousTimeToEvent/R/AnalyzeUsingBayesianNormals.R
@@ -17,23 +17,10 @@
 #' @export
 AnalyzeUsingBayesianNormals <- function(SimData, DesignParam, LookInfo = NULL, UserParam = NULL)
 {
-    
-    # setwd( "C:/AssuranceNormal/ExampleArgumentsFromEast/Example4")
-    # if( !file.exists("SimData.Rds"))
-    # {
-    #     saveRDS( SimData,     "SimData.Rds")
-    #    saveRDS( DesignParam, "DesignParam.Rds" )
-    #    saveRDS( UserParam,   "UserParam.Rds")
-    #    saveRDS( LookInfo,   "LookInfo.Rds")
-    # }
-    
-    
     bInterimAnalysis <- FALSE   # Assuming a fixed design, the next if statement will check this
 
     if( missing( LookInfo ) == FALSE && !is.null( LookInfo ) )
     {
-        
-        #saveRDS( LookInfo,    "LookInfo.Rds" )
         # Step 1 - If this is the IA then subset the data to include only those for the first look. East sends all simulated data
         
         if(  LookInfo$CurrLookIndex == 1 )

--- a/inst/Examples/ConsecutiveStudiesContinuousTimeToEvent/R/SimulatePatientOutcomeNormalAssurance.R
+++ b/inst/Examples/ConsecutiveStudiesContinuousTimeToEvent/R/SimulatePatientOutcomeNormalAssurance.R
@@ -21,17 +21,6 @@
 
 SimulatePatientOutcomeNormalAssurance <- function( NumSub, ArrivalTime, TreatmentID, Mean, StdDev, UserParam = NULL )
 {
-    
-    # Note: Example of how you could save the parameters in East. Do NOT setwd in Solara
-     #setwd( "C:/AssuranceNormal/ExampleArgumentsFromEast/Example2" )
-    # #if( !file.exists( "SimData.Rds" ) )
-    # #{
-        # saveRDS( NumSub,     "NumSub.Rds" )
-        # saveRDS( TreatmentID, "TreatmentID.Rds" )
-        # saveRDS( StdDev, "StdDev.Rds" )
-        # saveRDS( UserParam,   "UserParam.Rds" )
-    # #}
-    
     # Step 1 - Setup the vectors so we can sample which component of the mixture prior to use ####
     vStdDev     <- c( UserParam$dSDCtrl, UserParam$dSDExp )
     vMean       <- c( UserParam$dMeanCtrl )                     #Note: only need control mean as we will sample experimental mean

--- a/inst/Examples/DEPDecisionsUsingMCP/R/GetDEPDecisionsFSD.R
+++ b/inst/Examples/DEPDecisionsUsingMCP/R/GetDEPDecisionsFSD.R
@@ -28,7 +28,6 @@
 #'             }
 #'
 #'
-
 #' @note The current code assumes there are no dropouts. Modify the code accordingly for dropout case.
 ######################################################################################################################## .
 

--- a/inst/Examples/DEPDecisionsUsingMCP/R/GetDEPDecisionsFSD.R
+++ b/inst/Examples/DEPDecisionsUsingMCP/R/GetDEPDecisionsFSD.R
@@ -28,15 +28,7 @@
 #'             }
 #'
 #'
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 #' @note The current code assumes there are no dropouts. Modify the code accordingly for dropout case.
 ######################################################################################################################## .
 

--- a/inst/Examples/GeneratePoissonArrival/R/GeneratePoissonArrival.R
+++ b/inst/Examples/GeneratePoissonArrival/R/GeneratePoissonArrival.R
@@ -18,16 +18,6 @@
 #' If UserParam is not supplied, then PrdStart, AccrRate are used to simulate arrival times according to a Poisson process.  
 GeneratePoissonArrival  <- function(NumSub, NumPrd, PrdStart, AccrRate, UserParam = NULL )
 {
-
-    # setwd( "C:/GeneratePoissonArrival/ExampleArgumentsFromEast/Example1")
-    # saveRDS( NumSub,    "NumSub.Rds")
-    # saveRDS( NumPrd,    "NumPrd.Rds")
-    # saveRDS( PrdStart,  "PrdStart.Rds" )
-    # saveRDS( AccrRate,  "AccrRate.Rds" )
-    # saveRDS( UserParam, "UserParam.Rds" )
-    # Error = 0 --> No Error; 
-    # Error > 0 --> Non Fatal Error Particular Simulation will be aborted but Next Simulation will be performed
-    # Error < 0 --> Fatal Error - No further simulation will be attempted. We suggest that user should classify error in these categories depending on the context.
     # Step 1 - Initialize the return variables or other variables needed ####
     Error 	            <- 0  
     vPatientArrivalTime <- c() # Note, as you simulate the patient data put in in this vector so it can be returned

--- a/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpThatAreBetterThanCtrl-FillIn.R
+++ b/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpThatAreBetterThanCtrl-FillIn.R
@@ -19,13 +19,7 @@
 #' @note The order of AllocRatio should be the same as TreatmentID, and the  corresponding elements will have the assigned allocation ratio
 #' @note The returned vector ONLY includes TreatmentIDs for experimental treatments, eg TreatmentID = c( 0, 1, 2 ) is invalid, because you do NOT need to include 0 for control.
 #' @note You must return at LEAST one treatment and one allocation ratio
-
-
-#TODO(Kyle)-does that format work for examples/ helpful hints?
-
-
-
-
+#' 
 #' @examples  Example Output Object:
 #'       Example 1: Assuming the allocation in 2nd part of the trial is 1:2:2 for Control:Experimental 1:Experimental 2
 #'      vSelectedTreatments <- c( 1, 2 )  # Experimental 1 and 2 both have an allocation ratio of 2. 
@@ -45,7 +39,6 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-
 ######################################################################################################################## .
 
 SelectExpThatAreBetterThanCtrl  <- function(SimData, DesignParam, LookInfo)

--- a/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpThatAreBetterThanCtrl-FillIn.R
+++ b/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpThatAreBetterThanCtrl-FillIn.R
@@ -45,15 +45,7 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 ######################################################################################################################## .
 
 SelectExpThatAreBetterThanCtrl  <- function(SimData, DesignParam, LookInfo)
@@ -61,14 +53,6 @@ SelectExpThatAreBetterThanCtrl  <- function(SimData, DesignParam, LookInfo)
     # In this example, the majority of the code is provided.  The fill in the blank areas are noted by _____________________.
     # This is done to allow you to practice creating these examples. You will need to remove the ____________ and enter the correct code.
     # The fully worked examples are provided in the corresponding example R files. 
-    
-    
-    # Input objects can be saved through the following lines:
-    
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
     
     # Calculate the number of responders and treatment failures for each treatment
     

--- a/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpUsingBayesianRule-FillIn.R
+++ b/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpUsingBayesianRule-FillIn.R
@@ -59,15 +59,7 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 
 
 
@@ -82,13 +74,6 @@ SelectExpUsingBayesianRule  <- function(SimData, DesignParam, LookInfo, UserPara
     # 2)	Determine whether any experimental treatment has at least a treatmentPValue chance pj > historicResponseRate, eg for any treatment j if Pr( pj > historicResponseRate | data ) > treatmentPValue, select treatment j for stage 2.
     # 3)	If none of the treatments meet the above criteria for selection, then select the treatment with the largest Pr( pj > historicResponseRate | data ).
     # 4)	After selecting the treatments, use a randomization ratio of 2:1 (experimental: control) for all experimental treatments that are selected for stage 2
-    
-    
-    #Input objects can be saved through the following lines:
-    #setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
     
     # The below lines set the values of the parameters if a user does not specify a value
     

--- a/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpUsingBayesianRule-FillIn.R
+++ b/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpUsingBayesianRule-FillIn.R
@@ -33,13 +33,7 @@
 #' @note The order of AllocRatio should be the same as TreatmentID, and the  corresponding elements will have the assigned allocation ratio
 #' @note The returned vector ONLY includes TreatmentIDs for experimental treatments, eg TreatmentID = c( 0, 1, 2 ) is invalid, because you do NOT need to include 0 for control.
 #' @note You must return at LEAST one treatment and one allocation ratio
-
-
-#TODO(Kyle)-does the following format work for examples/ helpful hints?
-
-
-
-
+#' 
 #'@examples  Example Output Object:
 #'       Example 1: Assuming the allocation in 2nd part of the trial is 1:2:2 for Control:Experimental 1:Experimental 2
 #'       vSelectedTreatments <- c( 1, 2 )  # Experimental 1 and 2 both have an allocation ratio of 2. 
@@ -59,10 +53,6 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-
-
-
-
 ######################################################################################################################## .
 
 SelectExpUsingBayesianRule  <- function(SimData, DesignParam, LookInfo, UserParam= NULL)

--- a/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpWithPValueLessThanSpecified-FillIn.R
+++ b/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpWithPValueLessThanSpecified-FillIn.R
@@ -24,13 +24,7 @@
 #' @note The order of AllocRatio should be the same as TreatmentID, and the  corresponding elements will have the assigned allocation ratio
 #' @note The returned vector ONLY includes TreatmentIDs for experimental treatments, eg TreatmentID = c( 0, 1, 2 ) is invalid, because you do NOT need to include 0 for control.
 #' @note You must return at LEAST one treatment and one allocation ratio
-
-
-#TODO(Kyle)-does the following format work for examples/ helpful hints?
-
-
-
-
+#' 
 #'@examples  Example Output Object:
 #'       Example 1: Assuming the allocation in 2nd part of the trial is 1:2:2 for Control:Experimental 1:Experimental 2
 #'       vSelectedTreatments <- c( 1, 2 )  # Experimental 1 and 2 both have an allocation ratio of 2. 
@@ -50,7 +44,6 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-
 ######################################################################################################################## .
 
 SelectExpWithPValueLessThanSpecified  <- function(SimData, DesignParam, LookInfo, UserParam = NULL)

--- a/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpWithPValueLessThanSpecified-FillIn.R
+++ b/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectExpWithPValueLessThanSpecified-FillIn.R
@@ -50,15 +50,7 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 ######################################################################################################################## .
 
 SelectExpWithPValueLessThanSpecified  <- function(SimData, DesignParam, LookInfo, UserParam = NULL)
@@ -66,13 +58,6 @@ SelectExpWithPValueLessThanSpecified  <- function(SimData, DesignParam, LookInfo
     # In this example, the majority of the code is provided.  The fill in the blank areas are noted by _____________________.
     # This is done to allow you to practice creating these examples. You will need to remove the ____________ and enter the correct code.
     # The fully worked examples are provided in the corresponding example R files. 
-    
-    #Input objects can be saved through the following lines:
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-    
     
     if( is.null( UserParam ) )
     {

--- a/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectSpecifiedNumberOfExpWithHighestResponses-FillIn.R
+++ b/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectSpecifiedNumberOfExpWithHighestResponses-FillIn.R
@@ -55,15 +55,7 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 
 ######################################################################################################################## .
 
@@ -73,13 +65,6 @@ SelectSpecifiedNumberOfExpWithHighestResponses  <- function(SimData, DesignParam
     # In this example, the majority of the code is provided.  The fill in the blank areas are noted by _____________________.
     # This is done to allow you to practice creating these examples. You will need to remove the ____________ and enter the correct code.
     # The fully worked examples are provided in the corresponding example R files. 
-    
-    #Input objects can be saved through the following lines:
-    #setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-    
     
     if( is.null( UserParam ) )
     {

--- a/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectSpecifiedNumberOfExpWithHighestResponses-FillIn.R
+++ b/inst/Examples/TreatmentSelection/FillInTheBlankR/SelectSpecifiedNumberOfExpWithHighestResponses-FillIn.R
@@ -28,14 +28,7 @@
 #' @note The order of AllocRatio should be the same as TreatmentID, and the  corresponding elements will have the assigned allocation ratio
 #' @note The returned vector ONLY includes TreatmentIDs for experimental treatments, eg TreatmentID = c( 0, 1, 2 ) is invalid, because you do NOT need to include 0 for control.
 #' @note You must return at LEAST one treatment and one allocation ratio
-
-
-#TODO(Kyle)-does the following format work for examples/ helpful hints?
-#TODO(Kyle)-This script is written to have a user-specified number of treatment arms advanced and user-specified allocation ratios to the arms...code currently is set to work with two arms advanced
-#should we add a note explaining that if more than 2 trts are selected, there needs to be more user-specified allocation ratio variables
-
-
-
+#' 
 #'@examples  Example Output Object:
 #'       Example 1: Assuming the allocation in 2nd part of the trial is 1:2:2 for Control:Experimental 1:Experimental 2
 #'       vSelectedTreatments <- c( 1, 2 )  # Experimental 1 and 2 both have an allocation ratio of 2. 
@@ -55,8 +48,6 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-
-
 ######################################################################################################################## .
 
 

--- a/inst/Examples/TreatmentSelection/R/SelectExpThatAreBetterThanCtrl.R
+++ b/inst/Examples/TreatmentSelection/R/SelectExpThatAreBetterThanCtrl.R
@@ -38,28 +38,10 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-#' @note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
 #' @export
 ######################################################################################################################## .
 SelectExpThatAreBetterThanCtrl  <- function(SimData, DesignParam, LookInfo, UserParam=NULL)
 {
-    
-    # Input objects can be saved through the following lines:
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-    
     # Calculate the number of responders and treatment failures for each treatment
     
     # The next lines create a table where each treatment is in a row, number of treatment failures is the first column, and number of responses is the second column.

--- a/inst/Examples/TreatmentSelection/R/SelectExpThatAreBetterThanCtrl.R
+++ b/inst/Examples/TreatmentSelection/R/SelectExpThatAreBetterThanCtrl.R
@@ -40,6 +40,7 @@
 #'
 #' @export
 ######################################################################################################################## .
+
 SelectExpThatAreBetterThanCtrl  <- function(SimData, DesignParam, LookInfo, UserParam=NULL)
 {
     # Calculate the number of responders and treatment failures for each treatment

--- a/inst/Examples/TreatmentSelection/R/SelectExpUsingBayesianRule.R
+++ b/inst/Examples/TreatmentSelection/R/SelectExpUsingBayesianRule.R
@@ -33,16 +33,6 @@
 #' @note The order of AllocRatio should be the same as TreatmentID, and the corresponding elements will have the assigned allocation ratio
 #' @note The returned vector ONLY includes TreatmentIDs for experimental treatments, e.g., TreatmentID = c( 0, 1, 2 ) is invalid, because you do NOT need to include 0 for control.
 #' @note You must return at LEAST one treatment and one allocation ratio
-#' @note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example. It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them. This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'       saveRDS( UserParam,   "UserParam.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
 #' @export
 ######################################################################################################################## .
 
@@ -56,14 +46,7 @@ SelectExpUsingBayesianRule  <- function(SimData, DesignParam, LookInfo, UserPara
     # 3)	If none of the treatments meet the above criteria for selection, then select the treatment with the largest Pr( pj > UserParam$dHistoricResponseRate | data ).
     # 4)	After selecting the treatments, use a randomization ratio of 2:1 (experimental: control) for all experimental treatments that are selected for stage 2
 
-          
-    #Input objects can be saved through the following lines:
-    #setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-    
-    # The below lines set the values of the parameters if a user does not specify a value
+          # The below lines set the values of the parameters if a user does not specify a value
     
     if( is.null( UserParam ) )
     {

--- a/inst/Examples/TreatmentSelection/R/SelectExpUsingBayesianRule.R
+++ b/inst/Examples/TreatmentSelection/R/SelectExpUsingBayesianRule.R
@@ -22,7 +22,7 @@
 #' If none of the treatments meet the criteria for selection, then select the treatment with the largest Pr( pj > UserParam$dHistoricResponseRate | data ).
 #' User-specified pj ~ Beta( UserParam$dPriorAlpha, UserParam$dPriorBeta ). All experimental arms assume the same prior. 
 #' After the IA, use a randomization ratio of 2:1 (experimental:control) for all experimental treatments that are selected for stage 2.
-
+#' 
 #' @return TreatmentID  A vector that consists of the experimental treatments that were selected and carried forward. Experimental treatment IDs are 1, 2, ..., number of experimental treatments
 #' @return AllocRatio A vector that consists of the allocation for all experimental treatments that continue to the next phase.
 #' @return ErrorCode An integer value:  ErrorCode = 0 --> No Error
@@ -46,7 +46,7 @@ SelectExpUsingBayesianRule  <- function(SimData, DesignParam, LookInfo, UserPara
     # 3)	If none of the treatments meet the above criteria for selection, then select the treatment with the largest Pr( pj > UserParam$dHistoricResponseRate | data ).
     # 4)	After selecting the treatments, use a randomization ratio of 2:1 (experimental: control) for all experimental treatments that are selected for stage 2
 
-          # The below lines set the values of the parameters if a user does not specify a value
+    # The below lines set the values of the parameters if a user does not specify a value
     
     if( is.null( UserParam ) )
     {
@@ -58,7 +58,7 @@ SelectExpUsingBayesianRule  <- function(SimData, DesignParam, LookInfo, UserPara
     # The next lines create a table where each treatment is in a row, number of treatment failures is the first column, and number of responses is the second column.
     tabResults               <- table( SimData$TreatmentID, SimData$Response )
    
-     # Only want data on experimental treatments is wanted, experimental data starts in row 2
+    # Only want data on experimental treatments is wanted, experimental data starts in row 2
     tabResultsExperimental   <- tabResults[ c( 2:nrow( tabResults )), ]  
     nQtyOfExperimentalArms   <- nrow( tabResultsExperimental ) 
     

--- a/inst/Examples/TreatmentSelection/R/SelectExpWithPValueLessThanSpecified.R
+++ b/inst/Examples/TreatmentSelection/R/SelectExpWithPValueLessThanSpecified.R
@@ -43,26 +43,11 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 #' @export
 ######################################################################################################################## .
 SelectExpWithPValueLessThanSpecified  <- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 {
-    #Input objects can be saved through the following lines:
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-
-    
     if( is.null( UserParam ) )
     {
         UserParam <- list( dMaxPValue = 0 )

--- a/inst/Examples/TreatmentSelection/R/SelectExpWithPValueLessThanSpecified.R
+++ b/inst/Examples/TreatmentSelection/R/SelectExpWithPValueLessThanSpecified.R
@@ -43,9 +43,9 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-
 #' @export
 ######################################################################################################################## .
+
 SelectExpWithPValueLessThanSpecified  <- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 {
     if( is.null( UserParam ) )

--- a/inst/Examples/TreatmentSelection/R/SelectSpecifiedNumberOfExpWithHighestResponses.R
+++ b/inst/Examples/TreatmentSelection/R/SelectSpecifiedNumberOfExpWithHighestResponses.R
@@ -47,29 +47,10 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 #' @export
 SelectSpecifiedNumberOfExpWithHighestResponses  <- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 {
-          
-    # Input objects can be saved through the following lines:
-    # First set the working directory
-    # setwd(Sys.getenv("R_USER")) # You could specify the location directly. 
-    # setwd( "C://TreatmentSelection" )
-    # saveRDS( SimData, "SimData.Rds")
-    # saveRDS( DesignParam, "DesignParam.Rds" )
-    # saveRDS( LookInfo, "LookInfo.Rds" )
-    # saveRDS( UserParam, "UserParam.Rds")
-
-
     if( !exists( "UserParam" ) | is.null( UserParam ) )
     {
         # Default is to select the treatment with highest number of responses and allocation of 2:1 (Experimental:Control)

--- a/inst/Examples/TreatmentSelection/R/SelectSpecifiedNumberOfExpWithHighestResponses.R
+++ b/inst/Examples/TreatmentSelection/R/SelectSpecifiedNumberOfExpWithHighestResponses.R
@@ -47,8 +47,8 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-
 #' @export
+
 SelectSpecifiedNumberOfExpWithHighestResponses  <- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 {
     if( !exists( "UserParam" ) | is.null( UserParam ) )

--- a/inst/Templates/TreatmentSelection.R
+++ b/inst/Templates/TreatmentSelection.R
@@ -38,28 +38,12 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 ######################################################################################################################## .
 
 PerformTreatmentSelection  <- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 {
-           
-    # If you wanted to save the input objects you could use the following to save the files to your working directory
-    # Saving is not available in East Horizon Explore
-    # setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    # saveRDS( SimData, "SimData.Rds")
-    # saveRDS( DesignParam, "DesignParam.Rds" )
-    # saveRDS( LookInfo, "LookInfo.Rds" )
-    
-    # Pulling the important information from the simulated data, SimData, sent from East 
+   # Pulling the important information from the simulated data, SimData, sent from East 
     vTreatmentID    <- SimData$TreatmentID  # TreatmentIDs are 0, 1,..., number of experimental treatments
     vPatientOutcome <- SimData$Response     # Response = 0 or 1
     

--- a/inst/Templates/TreatmentSelection.R
+++ b/inst/Templates/TreatmentSelection.R
@@ -38,12 +38,11 @@
 #'                                    ErrorCode   = nErrorCode )
 #'       return( lReturn )
 #'
-
 ######################################################################################################################## .
 
 PerformTreatmentSelection  <- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 {
-   # Pulling the important information from the simulated data, SimData, sent from East 
+    # Pulling the important information from the simulated data, SimData, sent from East 
     vTreatmentID    <- SimData$TreatmentID  # TreatmentIDs are 0, 1,..., number of experimental treatments
     vPatientOutcome <- SimData$Response     # Response = 0 or 1
     
@@ -62,14 +61,14 @@ PerformTreatmentSelection  <- function(SimData, DesignParam, LookInfo, UserParam
     
     # Step 2: Perform any data analysis to decide which treatment(s) are selected ####
     
-    # TODO: Add any code here for analysis
+    # Add any code here for analysis
     
     
     # Step 3: Create the vector of experimental treatments that will continue to the next part of the trial ####
     # Example: 
     # vReturnTreatmentID <- c( 1, 2 ) # Always select treatment 1 and 2
     
-    # TODO: Add any code here for creating the treatment id vector
+    # Add any code here for creating the treatment id vector
     
     
     # Step 4: Create a vector of allocation ratios #### 
@@ -77,7 +76,7 @@ PerformTreatmentSelection  <- function(SimData, DesignParam, LookInfo, UserParam
     # Example: Put twice as many on experimental treatment 1 as there are on 2
     # vAllocationRatio   <- c( 2, 1 )    # This puts twice as many on Experimental treatment 1 because vReturnTreatmentID = c( 1, 2 ) in this example
     
-    # TODO: Add any code necessary for creating the allocation ratio vector.                                    
+    # Add any code necessary for creating the allocation ratio vector.                                    
     
     
     # If you use the variable vReturnTreatmentID and vAllocationRatio above, then the remainder of this code will perform a basic error check 

--- a/tests/testthat/TestCombineAllRFiles/AnalyzeUsingBetaBinomial.R
+++ b/tests/testthat/TestCombineAllRFiles/AnalyzeUsingBetaBinomial.R
@@ -38,8 +38,6 @@
 #' When using simulation to obtain the frequentist Operating Characteristic (OC) of a Bayesian design, you should set dLowerCutoffForFutility = 0
 #' when simulating under the null case in order to obtain the false-positive rate of the non-binding futility rule.  
 #' When you set dLowerCutoffForFutility > 0, simulation will provide the OC of the binding futility rule because the rule is ALWAYS followed. 
-
-#' TODO(Kyle): I am not sure how to define the alpha and beta user parameters. Could you define and add to documentation?
 #' @export
 ######################################################################################################################## .
 AnalyzeUsingBetaBinomial <- function(SimData, DesignParam, LookInfo, UserParam = NULL)

--- a/tests/testthat/TestCombineAllRFiles/AnalyzeUsingBetaBinomial.R
+++ b/tests/testthat/TestCombineAllRFiles/AnalyzeUsingBetaBinomial.R
@@ -38,15 +38,7 @@
 #' When using simulation to obtain the frequentist Operating Characteristic (OC) of a Bayesian design, you should set dLowerCutoffForFutility = 0
 #' when simulating under the null case in order to obtain the false-positive rate of the non-binding futility rule.  
 #' When you set dLowerCutoffForFutility > 0, simulation will provide the OC of the binding futility rule because the rule is ALWAYS followed. 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 #' TODO(Kyle): I am not sure how to define the alpha and beta user parameters. Could you define and add to documentation?
 #' @export
 ######################################################################################################################## .
@@ -104,12 +96,6 @@ AnalyzeUsingBetaBinomial <- function(SimData, DesignParam, LookInfo, UserParam =
         
     }
     
-    if( !file.exists( paste0( "SimData", nLookIndex, ".Rds") ))
-    {
-        saveRDS( SimData, paste0( "SimData", nLookIndex, ".Rds") )
-        saveRDS( DesignParam, paste0( "DesignParam", nLookIndex, ".Rds") )
-        saveRDS( LookInfo, paste0( "LookInfo", nLookIndex, ".Rds") )
-    }
     Error 	<- 0
     #retval 	= 0
     

--- a/tests/testthat/TestCombineAllRFiles/AnalyzeUsingEastManualFormula.R
+++ b/tests/testthat/TestCombineAllRFiles/AnalyzeUsingEastManualFormula.R
@@ -18,29 +18,12 @@
 #                                       ErrorCode > 0 --> Non fatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 #' @export
 ######################################################################################################################## .
 
 AnalyzeUsingEastManualFormula<- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 {
-    
-    # Input objects can be saved through the following lines:
-    
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-    
-    
     # Retrieve necessary information from the objects East sent
     nLookIndex           <- LookInfo$CurrLookIndex
     nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]

--- a/tests/testthat/TestCombineAllRFiles/AnalyzeUsingPropLimitsOfCI.R
+++ b/tests/testthat/TestCombineAllRFiles/AnalyzeUsingPropLimitsOfCI.R
@@ -30,15 +30,7 @@
 #                                       ErrorCode > 0 --> Non fatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 #'@note In this example, the boundary information that is computed and sent from East is ignored in order to implement this decision approach.
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 #' @export
 ######################################################################################################################## .
 AnalyzeUsingPropLimitsOfCI<- function(SimData, DesignParam, LookInfo, UserParam = NULL)
@@ -52,17 +44,6 @@ AnalyzeUsingPropLimitsOfCI<- function(SimData, DesignParam, LookInfo, UserParam 
     nQtyOfLooks          <- LookInfo$NumLooks
     nLookIndex           <- LookInfo$CurrLookIndex
     nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
-    
-    # Input objects can be saved through the following lines:
-    
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
-    
-    
-
-
     
     nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
     

--- a/tests/testthat/TestCombineAllRFiles/AnalyzeUsingPropLimitsOfCI.R
+++ b/tests/testthat/TestCombineAllRFiles/AnalyzeUsingPropLimitsOfCI.R
@@ -1,5 +1,4 @@
 ######################################################################################################################## .
-# TODO(Kyle)-Could you check that this documentation is correct (specifically the description)
 #' @param AnalyzeUsingPropLimitsOfCI
 #' @title Analyze using a simplified limits of confidence interval design
 #' @param SimData Data frame which consists of data generated in current simulation.

--- a/tests/testthat/TestCombineAllRFiles/AnalyzeUsingPropTest.R
+++ b/tests/testthat/TestCombineAllRFiles/AnalyzeUsingPropTest.R
@@ -21,7 +21,6 @@
 
 ######################################################################################################################## .
 
-#TODO(Kyle)- I am not sure where to substitute in the user parameters since most seems to be sent from East and then analyzed using prop.test
 #' @export
 AnalyzeUsingPropTest<- function(SimData, DesignParam, LookInfo, UserParam = NULL)
 { 

--- a/tests/testthat/TestCombineAllRFiles/AnalyzeUsingPropTest.R
+++ b/tests/testthat/TestCombineAllRFiles/AnalyzeUsingPropTest.R
@@ -18,37 +18,18 @@
 #                                       ErrorCode > 0 --> Non fatal error, current simulation is aborted but the next simulations will run
 #                                       ErrorCode < 0 --> Fatal error, no further simulation will be attempted
 
-#'@note Helpful Hints:
-#'       There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-#'       objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-#'
-#'       saveRDS( SimData,     "SimData.Rds")
-#'       saveRDS( DesignParam, "DesignParam.Rds" )
-#'       saveRDS( LookInfo,    "LookInfo.Rds" )
-#'
-#'       The above code will save each of the input objects to a file so they may be examined within R.
+
 ######################################################################################################################## .
 
 #TODO(Kyle)- I am not sure where to substitute in the user parameters since most seems to be sent from East and then analyzed using prop.test
 #' @export
 AnalyzeUsingPropTest<- function(SimData, DesignParam, LookInfo, UserParam = NULL)
-{
-    
-    
+{ 
     # Retrieve necessary information from the objects East sent
     nLookIndex           <- LookInfo$CurrLookIndex
     nQtyOfEvents         <- LookInfo$CumEvents[ nLookIndex ]
     
-    # Input objects can be saved through the following lines:
-    
-    #setwd( "[ENTER THE DIRECTORY WHERE YOU WANT TO SAVE DATA]")
-    #saveRDS( SimData, "SimData.Rds")
-    #saveRDS( DesignParam, "DesignParam.Rds" )
-    #saveRDS( LookInfo, "LookInfo.Rds" )
     nQtyOfPatsInAnalysis <- LookInfo$CumCompleters[ nLookIndex ]
-    
-    
-  
     
     # Create the vector of simulated data for this IA - East sends all of the simulated data
     vPatientOutcome      <- SimData$Response[ 1:nQtyOfPatsInAnalysis ]

--- a/tests/testthat/TestCombineAllRFiles/CreateCyneRgyFuntion.R
+++ b/tests/testthat/TestCombineAllRFiles/CreateCyneRgyFuntion.R
@@ -13,8 +13,6 @@ CreateCyneRgyFuntion <- function( strFunctionType, strNewFunctionName = "", strD
     strNewFileExt <- ".R"
     strNewFileName <- strNewFunctionName
     
-    
-    #TODO: Make sure the strFunctionType is a valid type, eg PatientSimulator, Analysis ect
     # Make sure the file does not already exist
     # create it and open it
     strPackage <- "CyneRgy"

--- a/tests/testthat/TestCombineAllRFiles/SelectExpThatAreBetterThanCtrl.Rd
+++ b/tests/testthat/TestCombineAllRFiles/SelectExpThatAreBetterThanCtrl.Rd
@@ -43,16 +43,6 @@ The returned vector ONLY includes TreatmentIDs for experimental treatments, eg T
 
 You must return at LEAST one treatment and one allocation ratio
 
-Helpful Hints:
-      There is often info that East sends to R that are not shown in a given example.  It can be very helpful to save the input 
-      objects and then load them into your R session and inspect them.  This can be done with the following R code in your function.
-
-      saveRDS( SimData,     "SimData.Rds")
-      
-      saveRDS( DesignParam, "DesignParam.Rds" )
-      
-      saveRDS( LookInfo,    "LookInfo.Rds" )
-
       The above code will save each of the input objects to a file so they may be examined within R.
 }
 \examples{

--- a/tests/testthat/TestCombineAllRFiles/SimulatePatientOutcomePercentAtZeroBetaDist.R
+++ b/tests/testthat/TestCombineAllRFiles/SimulatePatientOutcomePercentAtZeroBetaDist.R
@@ -22,10 +22,6 @@
 #' @export
 SimulatePatientOutcomePercentAtZeroBetaDist <- function(NumSub, TreatmentID, Mean, StdDev, UserParam = NULL)
 {
-    # Note: It can be helpful to save to the parameters that East sent.
-    # The next two lines show how you could save the UserParam variable to an Rds file
-    # setwd( "[ENTERED THE DESIRED LOCATION TO SAVE THE FILE]" )
-    # saveRDS(UserParam, "UserParam.Rds")
     
     # If the user did not specify the user parameters, but still called this function then the probability
     # of a 0 outcome is 0 for both treatments

--- a/tests/testthat/TestCombineAllRFiles/SimulatePatientSurvivalWeibull.r
+++ b/tests/testthat/TestCombineAllRFiles/SimulatePatientSurvivalWeibull.r
@@ -24,8 +24,6 @@
 #' @export
 SimulatePatientSurvivalWeibull<- function(NumSub, NumArm, TreatmentID, SurvMethod, NumPrd, PrdTime, SurvParam, UserParam = NULL ) 
 {
-    #TODO: Need to test that the paths that hit an error actually stop
-    
     # The SurvParam depends on input in East, EAST sends the Median (see the Simulation->Response Generation tab for what is sent)
     setwd( "C:\\Kyle\\Cytel\\Software\\East-R\\EastRExamples\\Examples\\2ArmTimeToEventOutcomePatientSimulation\\ExampleOutput")
 

--- a/tests/testthat/TestCombineAllRFiles/SimulatePatientSurvivalWeibull.r
+++ b/tests/testthat/TestCombineAllRFiles/SimulatePatientSurvivalWeibull.r
@@ -28,16 +28,6 @@ SimulatePatientSurvivalWeibull<- function(NumSub, NumArm, TreatmentID, SurvMetho
     
     # The SurvParam depends on input in East, EAST sends the Median (see the Simulation->Response Generation tab for what is sent)
     setwd( "C:\\Kyle\\Cytel\\Software\\East-R\\EastRExamples\\Examples\\2ArmTimeToEventOutcomePatientSimulation\\ExampleOutput")
- 
-    # If you wanted to save the input objects you could use the following to save the files to your working directory
-    
-    # Example of how to save the data sent from East for each look.
-    # If the DesignParam.Rds exists, then don't save it again.
-    if( !file.exists(  "DesignParam.Rds" ))
-    {
-        saveRDS( SurvParam, paste0( "SurvParam.Rds") )
-        # Use the same function as previous line if you want to save the other objects
-    }
 
     # For this example, in East the user must set the Input Method to Hazard Rate and have the # of pieces = 2. 
     # This will cause SurvParam to be a 2x2 matrix. 

--- a/tests/testthat/test-SimulatePatientSurvivalMixtureExponentials.R
+++ b/tests/testthat/test-SimulatePatientSurvivalMixtureExponentials.R
@@ -17,8 +17,6 @@ test_that("Test- SimulatePatientSurvivalMixtureExponentials", {
     NumPrd               <-1
     PrdTime             <-1
     
-    #TODO(kyle wathen) look up parameters for simulating survival data 
-    
     TreatmentID          <- c( rep(0,nQtyOfPatientsPerArm ), rep( 1, nQtyOfPatientsPerArm) )
    
     

--- a/tests/testthat/test-SimulatePatientSurvivalWeibull.R
+++ b/tests/testthat/test-SimulatePatientSurvivalWeibull.R
@@ -17,8 +17,6 @@ test_that("Test- SimulatePatientSurvivalWeibull", {
     NumPrd               <-1
     PrdTime             <-1
     
-    #TODO(kyle wathen) look up parameters for simulating survival data 
-    
     TreatmentID          <- c( rep(0,nQtyOfPatientsPerArm ), rep( 1, nQtyOfPatientsPerArm) )
     
     


### PR DESCRIPTION
This guidance on saving RDS files is outdated and applies to East, not East Horizon. To avoid confusion and ensure users receive accurate guidance, we should remove it.

Example:

```
   # Note: It can be helpful to save to the parameters that East sent.
    # The next two lines show how you could save the UserParam variable to an Rds file
    # setwd(["ENTER THE DESIRED LOCATION TO SAVE THE FILE"])
    # saveRDS( NumSub, "NumSub.Rds" )   
    # saveRDS( NumArm, "NumArm.Rds" )
    # saveRDS( TreatmentID, "TreatmentID.Rds" )
    # saveRDS( PropResp, "PropResp.Rds" )
    # saveRDS( UserParam, "UserParam.Rds") 
```